### PR TITLE
Remove deligation to avoid confusion of context for IltelliJ.

### DIFF
--- a/src/main/kotlin/ratpack/example/kotlin/Helpers.kt
+++ b/src/main/kotlin/ratpack/example/kotlin/Helpers.kt
@@ -39,7 +39,7 @@ class KChain (val delegate: Chain) : Chain by delegate {
 
 class KContext (val delegate: Context) : Context by delegate
 
-class KServerSpec(val delegate: RatpackServerSpec) : RatpackServerSpec by delegate {
+class KServerSpec(val delegate: RatpackServerSpec) {
     fun serverConfig(cb: ServerConfigBuilder.() -> Unit) = delegate.serverConfig { it.cb() }
     fun registry(cb: RegistrySpec.() -> Unit) = delegate.registry (Registry.of(cb))
     fun guiceRegistry(cb: BindingsSpec.() -> Unit) =


### PR DESCRIPTION
Currently IntelliJ shows fun inside closure in the Main.kt class as unknown. It cannot find them in RatpackServerSpec context. They are defined in KServerSpec, but get confused by delegation.

Once I removed delegation from KServerSpec everything works fine and IntelliJ is happy.
